### PR TITLE
Update config to add additional regions as inputs to bed file generat…

### DIFF
--- a/egg5_config.py
+++ b/egg5_config.py
@@ -298,8 +298,8 @@ cnv_rea_dynamic_files = {
     "{}.gene_panels".format(cnv_generate_bed_excluded_stage_id): "",
     "{}.manifest ID".format(cnv_generate_bed_excluded_stage_id): bioinformatic_manifest,
     "{}.manifest".format(cnv_generate_bed_excluded_stage_id): "",
-    "{}.additional_regions ID".format(cnv_generate_bed_vep_stage_id): additional_regions,
-    "{}.additional_regions".format(cnv_generate_bed_vep_stage_id): "",
+    "{}.additional_regions ID".format(cnv_generate_bed_excluded_stage_id): additional_regions,
+    "{}.additional_regions".format(cnv_generate_bed_excluded_stage_id): "",
     # inputs for excluded app
     "{}.cds_hgnc ID".format(cnv_annotate_excluded_regions_stage_id): cds_file,
     "{}.cds_hgnc".format(cnv_annotate_excluded_regions_stage_id): "",

--- a/egg5_config.py
+++ b/egg5_config.py
@@ -9,7 +9,7 @@ from dias_dynamic_files import (
 )
 
 assay_name = "CEN" # Core Endo Neuro
-assay_version = "v1.2.1"
+assay_version = "v1.2.2"
 
 ref_project_id = "project-Fkb6Gkj433GVVvj73J7x8KbV"
 
@@ -241,6 +241,8 @@ cnv_rpt_dynamic_files = {
     "{}.gene_panels".format(cnv_generate_bed_vep_stage_id): "",
     "{}.manifest ID".format(cnv_generate_bed_vep_stage_id): bioinformatic_manifest,
     "{}.manifest".format(cnv_generate_bed_vep_stage_id): "",
+    "{}.additional_regions ID".format(cnv_generate_bed_vep_stage_id): additional_regions,
+    "{}.additional_regions".format(cnv_generate_bed_vep_stage_id): "",
     # inputs for generate bed for excluded app
     "{}.exons_nirvana ID".format(cnv_generate_bed_excluded_stage_id): cds_file,
     "{}.exons_nirvana".format(cnv_generate_bed_excluded_stage_id): "",
@@ -250,6 +252,8 @@ cnv_rpt_dynamic_files = {
     "{}.gene_panels".format(cnv_generate_bed_excluded_stage_id): "",
     "{}.manifest ID".format(cnv_generate_bed_excluded_stage_id): bioinformatic_manifest,
     "{}.manifest".format(cnv_generate_bed_excluded_stage_id): "",
+    "{}.additional_regions ID".format(cnv_generate_bed_excluded_stage_id): additional_regions,
+    "{}.additional_regions".format(cnv_generate_bed_excluded_stage_id): "",
     # inputs for excluded app
     "{}.cds_hgnc ID".format(cnv_annotate_excluded_regions_stage_id): cds_file,
     "{}.cds_hgnc".format(cnv_annotate_excluded_regions_stage_id): "",
@@ -283,7 +287,9 @@ cnv_rea_dynamic_files = {
     "{}.nirvana_genes2transcripts".format(cnv_generate_bed_vep_stage_id): "",
     "{}.gene_panels ID".format(cnv_generate_bed_vep_stage_id): genepanels_file,
     "{}.gene_panels".format(cnv_generate_bed_vep_stage_id): "",
-    # inputs for generate bed for excluded app
+    "{}.additional_regions ID".format(cnv_generate_bed_vep_stage_id): additional_regions,
+    "{}.additional_regions".format(cnv_generate_bed_vep_stage_id): "",
+# inputs for generate bed for excluded app
     "{}.exons_nirvana ID".format(cnv_generate_bed_excluded_stage_id): cds_file,
     "{}.exons_nirvana".format(cnv_generate_bed_excluded_stage_id): "",
     "{}.nirvana_genes2transcripts ID".format(cnv_generate_bed_excluded_stage_id): genes2transcripts,
@@ -292,6 +298,8 @@ cnv_rea_dynamic_files = {
     "{}.gene_panels".format(cnv_generate_bed_excluded_stage_id): "",
     "{}.manifest ID".format(cnv_generate_bed_excluded_stage_id): bioinformatic_manifest,
     "{}.manifest".format(cnv_generate_bed_excluded_stage_id): "",
+    "{}.additional_regions ID".format(cnv_generate_bed_vep_stage_id): additional_regions,
+    "{}.additional_regions".format(cnv_generate_bed_vep_stage_id): "",
     # inputs for excluded app
     "{}.cds_hgnc ID".format(cnv_annotate_excluded_regions_stage_id): cds_file,
     "{}.cds_hgnc".format(cnv_annotate_excluded_regions_stage_id): "",


### PR DESCRIPTION
- Update config to add additional regions as inputs to bed file generation stages in cnv reports. 
- Update config version

Note that the additional regions file has been previously demonstrated to work correctly with generate bed, but was not included in the assay config. 
https://cuhbioinformatics.atlassian.net/wiki/spaces/C/pages/2808676399/CEN+CNV+additional+regions+b37+v1.0.1.tsv

Initial testing here to demonstrate that the change has the intended effect of adding the additional regions file as input to generate bed stages:
https://platform.dnanexus.com/projects/GK7vp8Q4q73FFYx351P8fJy3/monitor/analysis/GK7xGQj4q733X72J4kFPF3KX

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_cen_config/20)
<!-- Reviewable:end -->
