### PR TITLE
Update vep config to v1.1.6 to include Clinvar version 20230819

### DIFF
--- a/egg5_config_v2.0.4.py
+++ b/egg5_config_v2.0.4.py
@@ -1,5 +1,5 @@
 assay_name = "CEN" # Core Endo Neuro
-assay_version = "v2.0.3"
+assay_version = "v2.0.4"
 
 ref_project_id = "project-Fkb6Gkj433GVVvj73J7x8KbV"
 
@@ -22,7 +22,7 @@ exons_file = "{}:file-GF611Z8433Gf99pBPbJkV7bq".format(ref_project_id)
 
 ## for eggd_VEP
 # VEP config file for SNV reports v1.1.5
-vep_config = "{}:file-GXvYjx04z6jKjvJy191X0511".format(ref_project_id)
+vep_config = "{}:file-GYX83Kj4z6jFbKy9fVj44BYK".format(ref_project_id)
 # VEP config file for CNV reports v1.1.0
 cnv_vep_config =  "{}:file-GQGJ3Z84xyx0jp1q65K1Q1jY".format(ref_project_id)
 


### PR DESCRIPTION
Updates:

- changed assay_version from `v2.0.3` to `v2.0.4`
- changed vep_config to` cen_vep_config_v1.1.6.json` to include Clinvar version 20230819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/35)
<!-- Reviewable:end -->
