### PR TITLE
add athena thresholds

### DIFF
--- a/egg5_config_v2.2.0.py
+++ b/egg5_config_v2.2.0.py
@@ -143,6 +143,8 @@ mosaic_rpt_dynamic_files = {
     "{}.exons_file ID".format(athena_stage_id): exons_file,
     "{}.exons_file".format(athena_stage_id): "",
     "{}.limit".format(athena_stage_id): "260",
+    "{}.thresholds".format(athena_stage_id): "100, 250, 500, 1000, 1500",
+    "{}.cutoff_threshold".format(athena_stage_id): "250",
     "{}.summary".format(athena_stage_id): "true"
 }
 


### PR DESCRIPTION
adds extra options for athena to match validation for mosaic variant calling 

    "{}.thresholds".format(athena_stage_id): "100, 250, 500, 1000, 1500",
    "{}.cutoff_threshold".format(athena_stage_id): "250",

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/42)
<!-- Reviewable:end -->
