### PR TITLE
Update CEN VEP config and GATKgCNV_call app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Workflows:
 
 Apps:
 * CNV calling app: **eggd_GATKgCNV_call**
-    * v1.0.1 
-    * DNAnexus app ID: `app-GJZVB2840KK0kxX998QjgXF0`
+    * v1.0.2
+    * DNAnexus app ID: `app-GZ4pXxj4xG062Bj5zjgP1Bb0`
 
 Dynamic files:
 | File      | File name | DNAnexus file ID |
@@ -34,7 +34,7 @@ Dynamic files:
 | genes2transcripts | **230421_g2t.tsv** | `file-GV4P970433Gj6812zGVBZvB4` |
 | exons_nirvana | **GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gk7gZ47gypK7ZZ` |
 | exons_file for eggd_athena | **GCF_000001405.25_GRCh37.p13_genomic.symbols.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gf99pBPbJkV7bq` |
-| cen_vep_config for SNV reports | **cen_vep_config_v1.1.6.json** | `file-GYX83Kj4z6jFbKy9fVj44BYK` |
+| cen_vep_config for SNV reports | **cen_vep_config_v1.1.7.json** | `file-GZ9F1GQ4z6j22q8KXVpBP147` |
 | cen_vep_config for CNV reports | **cen-cnv_config_v1.1.0.json** | `file-GQGJ3Z84xyx0jp1q65K1Q1jY` |
 | additional_regions for CNVs | **CEN_CNV_additional_regions_b37_v1.0.1.tsv** | `file-GJZQvg0433GkyFZg13K6VV6p` |
 | gatk_docker | **GATK_v4.2.5.0.tar.gz** | `file-GBBP9JQ433GxV97xBpQkzYZx` |

--- a/egg5_config_v2.3.0.py
+++ b/egg5_config_v2.3.0.py
@@ -1,5 +1,5 @@
 assay_name = "CEN" # Core Endo Neuro
-assay_version = "v2.2.0"
+assay_version = "v2.3.0"
 
 ref_project_id = "project-Fkb6Gkj433GVVvj73J7x8KbV"
 
@@ -21,8 +21,8 @@ vep_bed_flank = 495
 exons_file = "{}:file-GF611Z8433Gf99pBPbJkV7bq".format(ref_project_id)
 
 ## for eggd_VEP
-# VEP config file for SNV reports v1.1.6
-vep_config = "{}:file-GYX83Kj4z6jFbKy9fVj44BYK".format(ref_project_id)
+# VEP config file for SNV reports v1.1.7
+vep_config = "{}:file-GZ9F1GQ4z6j22q8KXVpBP147".format(ref_project_id)
 # VEP config file for CNV reports v1.1.0
 cnv_vep_config =  "{}:file-GQGJ3Z84xyx0jp1q65K1Q1jY".format(ref_project_id)
 
@@ -33,8 +33,8 @@ additional_regions = "{}:file-GJZQvg0433GkyFZg13K6VV6p".format(ref_project_id)
 ### Apps and workflows:
 
 # GATKgCNV_call
-# v1.0.1
-cnvcall_app_id = "app-GJZVB2840KK0kxX998QjgXF0"
+# v1.0.2
+cnvcall_app_id = "app-GZ4pXxj4xG062Bj5zjgP1Bb0"
 
 cnvcalling_fixed_inputs = {
     # GATK Docker image tar v4.2.5.0


### PR DESCRIPTION
Changes:

- Update assay version to v2.3.0
- Update CEN VEP config to v1.1.7
- Update GATKgCNV_call app to v1.0.2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/43)
<!-- Reviewable:end -->
