### PR TITLE
Add url duration field as artemis input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 >
 > When new eggd_dias_batch goes live the python script will be deleted
 
-# dias_CEN_config_GRCh37_v3.0.1.json
+# dias_CEN_config_GRCh37_v3.0.2.json
 
 This repo contains a JSON config file which is used with eggd_dias_batch to specify inputs for running the Dias pipeline for CEN data.
 

--- a/dias_CEN_config_GRCh37_v3.0.2.json
+++ b/dias_CEN_config_GRCh37_v3.0.2.json
@@ -1,6 +1,6 @@
 {
     "assay": "CEN",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "cnv_call_app_id": "app-GZ4pXxj4xG062Bj5zjgP1Bb0",
     "artemis_app_id": "app-GZ1X5zj4K5ZxyfYPPq4YgGv3",
     "snv_report_workflow_id": "workflow-GXzkfYj4QPQp9z4Jz4BF09y6",

--- a/dias_CEN_config_GRCh37_v3.0.2.json
+++ b/dias_CEN_config_GRCh37_v3.0.2.json
@@ -180,6 +180,7 @@
         },
         "artemis": {
             "inputs": {
+                "url_duration": 15811200,
                 "capture_bed": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",


### PR DESCRIPTION
Change artemis inputs to include url_duration of 15811200 seconds (=6 months). This means the dx download links generated by artemis will work for six months before they expire.

eggd_dias_batch job using this config: https://platform.dnanexus.com/panx/projects/Gf6fPz046k5582p9PvFYf8ZZ/monitor/job/Gf792Z046k53kb4K9pjZx9yZ
eggd_artemis job set off by the above batch job using 15811200 as the url_duration input: https://platform.dnanexus.com/panx/projects/Gf6fPz046k5582p9PvFYf8ZZ/monitor/job/Gf7934Q46k5JkpPvyGVvbP74

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/52)
<!-- Reviewable:end -->
