### PR TITLE
Update to include cen_vep_config_v1.1.17.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dias_CEN_config_GRCh37_v3.1.5.json
+# dias_CEN_config_GRCh37_v3.1.6.json
 
 This repo contains a JSON config file which is used with eggd_dias_batch to specify inputs for running the Dias pipeline for CEN data.
 
@@ -44,7 +44,7 @@ Dynamic files:
 | exons | **GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gk7gZ47gypK7ZZ` |
 | genes2transcripts | **240402_g2t.tsv** | `file-Gj770X8433Gb506pjq1PxXG9` |
 | exons_with_symbols for eggd_athena | **GCF_000001405.25_GRCh37.p13_genomic.symbols.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gf99pBPbJkV7bq` |
-| cen_vep_config for SNV/mosaic reports | **cen_vep_config_v1.1.16.json** | `file-GkkF90j4z6j9vqqvjJz786jb` |
+| cen_vep_config for SNV/mosaic reports | **cen_vep_config_v1.1.17.json** | `file-GpV6G9Q4z6jKJ2qVFGK1v0g2` |
 | cen_vep_config for CNV reports | **cen-cnv_config_v1.1.0.json** | `file-GQGJ3Z84xyx0jp1q65K1Q1jY` |
 | panel_dump for eggd_optimised_filtering | **240202_panelapp_dump.json** | `file-Gg35Vf845B5bV08VqJ0qGV5V` |
 | additional_regions for CNVs | **CEN_CNV_additional_regions_b37_v1.0.1.tsv** | `file-GJZQvg0433GkyFZg13K6VV6p` |

--- a/dias_CEN_config_GRCh37_v3.1.6.json
+++ b/dias_CEN_config_GRCh37_v3.1.6.json
@@ -1,6 +1,6 @@
 {
     "assay": "CEN",
-    "version": "3.1.5",
+    "version": "3.1.6",
     "cnv_call_app_id": "app-GZ4pXxj4xG062Bj5zjgP1Bb0",
     "artemis_app_id": "app-GkbJ7p0463bjk9VKv3x8G5F8",
     "snv_report_workflow_id": "workflow-GkbJY284FpfgqF8ggz57fVY2",
@@ -183,7 +183,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GkkF90j4z6j9vqqvjJz786jb"
+                        "id": "file-GpV6G9Q4z6jKJ2qVFGK1v0g2"
                     }
                 },
                 "stage-rpt_vep.vcf": {


### PR DESCRIPTION
In README.md:
- increment version number of batch config referenced:
- dias_CEN_config_GRCh37_v3.1.5.json → dias_CEN_config_GRCh37_v3.1.6.json

In dias_CEN_config_GRCh37_v3.1.6.json:
- increment version number of config via git mv dias_CEN_config_GRCh37_v3.1.5.json → dias_CEN_config_GRCh37_v3.1.6.json
- increment version number within config "version": "3.1.5" --> "version": "3.1.6"

Update vep config file:
- “id" : 'file-GkkF90j4z6j9vqqvjJz786jb' → 'file-GpV6G9Q4z6jKJ2qVFGK1v0g2'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/72)
<!-- Reviewable:end -->
