### PR TITLE
Update to use cen_vep_config_v1.1.22 - BunnyNo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dynamic files:
 | exons | **GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gk7gZ47gypK7ZZ` |
 | genes2transcripts | **240402_g2t.tsv** | `file-Gj770X8433Gb506pjq1PxXG9` |
 | exons_with_symbols for eggd_athena | **GCF_000001405.25_GRCh37.p13_genomic.symbols.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gf99pBPbJkV7bq` |
-| cen_vep_config for SNV/mosaic reports | **cen_vep_config_v1.1.21.json** | `file-Gx2kJyj4z6j5qZYy2fVBzVk4` |
+| cen_vep_config for SNV/mosaic reports | **cen_vep_config_v1.1.22.json** | `file-GxVBbFj4z6j56j24YkVPJGx0` |
 | cen_vep_config for CNV reports | **cen-cnv_config_v1.1.0.json** | `file-GQGJ3Z84xyx0jp1q65K1Q1jY` |
 | panel_dump for eggd_optimised_filtering | **241030_panelapp_dump.json** | `file-GvVg3qj4Y54jBF8bgX62gkfQ` |
 | additional_regions for CNVs | **CEN_CNV_additional_regions_b37_v1.0.1.tsv** | `file-GJZQvg0433GkyFZg13K6VV6p` |

--- a/dias_CEN_config_GRCh37_v3.2.2.json
+++ b/dias_CEN_config_GRCh37_v3.2.2.json
@@ -1,6 +1,6 @@
 {
     "assay": "CEN",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "cnv_call_app_id": "app-GZ4pXxj4xG062Bj5zjgP1Bb0",
     "artemis_app_id": "app-GkbJ7p0463bjk9VKv3x8G5F8",
     "snv_report_workflow_id": "workflow-GkbJY284FpfgqF8ggz57fVY2",
@@ -129,7 +129,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-Gx2kJyj4z6j5qZYy2fVBzVk4"
+                        "id": "file-GxVBbFj4z6j56j24YkVPJGx0"
                     }
                 },
                 "stage-rpt_vep.vcf": {
@@ -189,7 +189,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-Gx2kJyj4z6j5qZYy2fVBzVk4"
+                        "id": "file-GxVBbFj4z6j56j24YkVPJGx0"
                     }
                 },
                 "stage-rpt_vep.vcf": {


### PR DESCRIPTION
- Filename incremented from dias_CEN_config_GRCh37_v3.2.1.json → dias_CEN_config_GRCh37_v3.2.2.json

- Version incremented
    - v3.2.1 -> v3.2.2

- Vep config file ID updated
  - Increment version number within config
  - "version": "3.2.1" --> "version": "3.2.2"

- Update vep config file id in both SNV and mosaic reports:
  - "stage-rpt_vep.config_file" : file-GxVBbFj4z6j56j24YkVPJGx0


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/87)
<!-- Reviewable:end -->
