### PR TITLE
DI-565 GRCh38 v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,15 @@ The `modes` section specifies inputs specific to a running mode:
 * artemis
     * specifies inputs for [artemis](https://github.com/eastgenomics/eggd_artemis)
 
-
-## Versions of workflows, apps, and dynamic files in the config
-Workflows:
-* Dias reports: **dias_reports_v2.2.2**
-    * DNAnexus workflow ID: `workflow-GkbJY284FpfgqF8ggz57fVY2`
-* Dias CNV reports: **dias_cnvreports_v1.2.0**
-    * DNAnexus workflow ID: `workflow-Gj77F9041Ky3Vp045gpKx0B4`
-
 # Versions of apps, files, and docker images in the config
 The following table lists the versions of apps, files, and docker images used in the config for both GRCh38 and GRCh37. The DNAnexus file IDs are provided for each file.
 
 | Type | File Description | GRCh38 File Name | GRCh38 DNAnexus File ID | GRCh37 File Name | GRCh37 DNAnexus File ID |
 |------|------------------|------------------|--------------------------|------------------|--------------------------|
-| app | dias_reports | **dias_reports_v2.2.2** | `app-GkbJY284FpfgqF8ggz57fVY2` | **dias_reports_v2.2.2** | `app-GkbJY284FpfgqF8ggz57fVY2` |
-| app | dias_cnvreports | **dias_cnvreports_v1.2.0** | `app-Gj77F9041Ky3Vp045gpKx0B4` | **dias_cnvreports_v1.2.0** | `app-Gj77F9041Ky3Vp045gpKx0B4` |
+| workflow | dias_reports | **dias_reports_v2.2.2** | `workflow-GkbJY284FpfgqF8ggz57fVY2` | **dias_reports_v2.2.2** | `workflow-GkbJY284FpfgqF8ggz57fVY2` |
+| workflow | dias_cnvreports | **dias_cnvreports_v1.2.0** | `workflow-Gj77F9041Ky3Vp045gpKx0B4` | **dias_cnvreports_v1.2.0** | `workflow-Gj77F9041Ky3Vp045gpKx0B4` |
 | app | eggd_GATKgCNV_call | **eggd_GATKgCNV_call_v2.0.0** | `app-GvZB5p846Vg69fBg0Fq10938` | **eggd_GATKgCNV_call_v2.0.0** | `app-GvZB5p846Vg69fBg0Fq10938` |
-| app | eggd_artemis | **eggd_artemis_v1.6.0** | `app-Gk1Z0bQ4KzQzXkJ3Xg53ypXv` | **eggd_artemis_v1.5.0** | `app-GkbJ7p0463bjk9VKv3x8G5F8` |
+| app | eggd_artemis | **eggd_artemis_v1.6.0** | `app-GxVK0bQ4KzQzXkJ3Xg53ypXv` | **eggd_artemis_v1.5.0** | `app-GkbJ7p0463bjk9VKv3x8G5F8` |
 | file | genepanels | **250528_genepanels.tsv** | `file-J0qJKv04Kp44F8JB3004390k` | **241024_genepanels.tsv** | `file-GvJ5fbQ4qQYq73gjGyP57zFB` |
 | file | exons | **GCF_000001405.39_GRCh38.p13_genomic_20211119.exon_5bp.tsv** | `file-GyFfgpQ4fJPv132574bFQfV5` | **GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gk7gZ47gypK7ZZ` |
 | file | genes2transcripts | **g2t_grch38_v2.0.0.tsv** | `file-J0v6GyQ4zqZJV047q56PqFx5` | **240402_g2t.tsv** | `file-Gj770X8433Gb506pjq1PxXG9` |
@@ -46,12 +38,11 @@ The following table lists the versions of apps, files, and docker images used in
 | config | cen_vep_config for CNV reports | **cen-cnv_config_GRCh38_v1.0.0.json** | `file-GyXyyp04Q8Xpj5fJ8v45by9k` | **cen-cnv_config_v1.1.0.json** | `file-GQGJ3Z84xyx0jp1q65K1Q1jY` |
 | file | panel_dump for eggd_optimised_filtering | **250530_panelapp_dump.json** | `file-J0yk3V04VVYxJ9bz3QPPzxPg` | **241030_panelapp_dump.json** | `file-GvVg3qj4Y54jBF8bgX62gkfQ` |
 | file | additional_regions for CNVs | **CEN_CNV_additional_regions_b38_v1.0.0.tsv** | `file-GfKb08j4679f4jbfxf8XP7JZ` | **CEN_CNV_additional_regions_b37_v1.0.1.tsv** | `file-GJZQvg0433GkyFZg13K6VV6p` |
-| file | additional_regions for SNVs | **CEN_SNV_additional_regions_GRCh38_v1.0.0.tsv** | `file-GzQbVP84Pp8KVYX605PV7vfp` | **CEN_SNV_additional_regions_b37_v1.0.0.tsv** | `file-Gpy96q04PKYjjg9kbQy692bF` |
+| file | additional_regions for SNVs | **CEN_SNV_additional_regions_GRCh38_v1.0.0.tsv** | `file-J0zJ06Q4Pp80Q73204yZkzvz` | **CEN_SNV_additional_regions_b37_v1.0.0.tsv** | `file-Gpy96q04PKYjjg9kbQy692bF` |
 | docker | gatk_docker | **GATK_v4.6.0.0.tar.gz** | `file-GpZz87Q4ZbZkxJJGx9b02gyV` | **GATK_v4.6.0.0.tar.gz** | `file-GpZz87Q4ZbZkxJJGx9b02gyV` |
 | file | interval_list for CNV calling | **CEN_CNV_targets_b38_v1.0.0.interval_list** | `file-GfFGFP04z704bp38ykFvgX03` | **CEN_CNV_targets_v1.1.0_sorted.interval_list** | `file-GFPxzKj4V50pJX3F4vV58yyg` |
 | file | annotation of interval_list for CNV calling | **CEN_CNV_targets_b38_v1.0.0_annotation.tsv** | `file-GfFGFPQ4z70JG5VPQP28V1PV` | **CEN_CNV_targets_v1.1.0_sorted_annotation.tsv** | `file-GFPxzPQ4V50z4pv230p82G0q` |
 | file | capture bed for artemis | **CEN_CNV_targets_b38_v1.0.0.bed** | `file-Gf0gX1Q4XGyqKzj4yFJyy0XV` | **CEN_CNV_targets_b37_v1.1.0.bed** | `file-GFPxpJj4GVV0Pfzv4VGYf1pq` |
-
 
 ## Cmd to check the config file ids (not comprehensive)
 ```bash

--- a/dias_CEN_config_GRCh38_v4.0.0.json
+++ b/dias_CEN_config_GRCh38_v4.0.0.json
@@ -123,7 +123,7 @@
                 "stage-rpt_generate_bed_vep.additional_regions": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GzQbVP84Pp8KVYX605PV7vfp"
+                        "id": "file-J0zJ06Q4Pp80Q73204yZkzvz"
                     }
                 },
                 "stage-rpt_vep.config_file": {
@@ -156,10 +156,11 @@
                 "stage-rpt_generate_workbook.summary": "dias",
                 "stage-rpt_generate_workbook.filter": "bcftools filter -e 'FILTER==\"EXCLUDE\"'",
                 "stage-rpt_generate_workbook.human_filter": "Variants with ClinVar individual or aggregate classifications of Likely pathogenic/Pathogenic are always included, regardless of any other filtering rules. Variants with an HGMD variant class of DM are always included, regardless of other filtering rules. Variants with gnomAD exomes or genomes AF exceeding the threshold associated with the mode of inheritance of the gene are excluded. These thresholds are 0.1% for monoallelic inheritance, 1.0% for all other modes of inheritance. Variants with CEN cohort AF exceeding 5.0% are excluded. Variants with consequences equal to one of the following Sequence Ontology terms are excluded, unless they also have an HGMD variant class of DM?: synonymous_variant\\intron_variant\\upstream_gene_variant\\downstream_gene_variant\\intergenic_variant\\5_prime_UTR_variant\\3_prime_UTR_variant. Variants specified in the include list are always included, regardless of other filtering rules. Variants specified in the exclude list are always excluded, regardless of other filtering rules.",
-                "stage-rpt_generate_workbook.reorder_columns": "CHROM POS REF ALT GT GQ DP_FMT AD CSQ_SYMBOL CSQ_EXON CSQ_INTRON CSQ_HGVSc CSQ_HGVSp CSQ_Consequence CSQ_IMPACT CSQ_VARIANT_CLASS CSQ_gnomADe_AF CSQ_gnomADe_AF_grpmax CSQ_gnomADe_Hom CSQ_gnomADe_AC CSQ_gnomADe_AN CSQ_gnomADe_nhomalt CSQ_gnomADg_AF CSQ_gnomADg_AF_grpmax CSQ_gnomADg_AC CSQ_gnomADg_AN CSQ_gnomADg_nhomalt CSQ_CEN_AF CSQ_CEN_AC_Hom CSQ_CEN_AC_Het CSQ_CEN_AN CSQ_TWE_AF CSQ_TWE_AC_Hom CSQ_TWE_AC_Het CSQ_TWE_AN CSQ_HGMD CSQ_HGMD_CLASS CSQ_HGMD_RANKSCORE CSQ_HGMD_PHEN CSQ_Existing_variation CSQ_ClinVar CSQ_ClinVar_CLNDN CSQ_ClinVar_CLNSIG CSQ_Mastermind_MMID3 CSQ_CADD_PHRED CSQ_REVEL CSQ_SpliceAI_pred_DS_AG CSQ_SpliceAI_pred_DS_AL CSQ_SpliceAI_pred_DS_DG CSQ_SpliceAI_pred_DS_DL CSQ_HGVS_OFFSET CSQ_STRAND CSQ_Feature MOI",
+                "stage-rpt_generate_workbook.reorder_columns": "CHROM POS REF ALT GT GQ DP_FMT AD CSQ_SYMBOL CSQ_EXON CSQ_INTRON CSQ_HGVSc CSQ_HGVSp CSQ_Consequence CSQ_IMPACT CSQ_VARIANT_CLASS CSQ_gnomADe_AF CSQ_gnomADe_AF_grpmax CSQ_gnomADe_Hom CSQ_gnomADe_AC CSQ_gnomADe_AN CSQ_gnomADe_nhomalt CSQ_gnomADg_AF CSQ_gnomADg_AF_grpmax CSQ_gnomADg_AC CSQ_gnomADg_AN CSQ_gnomADg_nhomalt CSQ_CEN_AF CSQ_CEN_AC_Hom CSQ_CEN_AC_Het CSQ_CEN_AN CSQ_TWE_AF CSQ_TWE_AC_Hom CSQ_TWE_AC_Het CSQ_TWE_AN CSQ_HGMD CSQ_HGMD_CLASS CSQ_HGMD_RANKSCORE CSQ_HGMD_PHEN CSQ_Existing_variation CSQ_ClinVar CSQ_ClinVar_CLNDN CSQ_ClinVar_CLNSIG CSQ_Mastermind_MMID3 CSQ_CADD_PHRED CSQ_REVEL CSQ_SpliceAI_pred_DS_AG CSQ_SpliceAI_pred_DS_AL CSQ_SpliceAI_pred_DS_DG CSQ_SpliceAI_pred_DS_DL decipher CSQ_HGVS_OFFSET CSQ_STRAND CSQ_Feature MOI",
                 "stage-rpt_generate_workbook.keep_filtered": false,
                 "stage-rpt_generate_workbook.freeze_column": "N2",
                 "stage-rpt_generate_workbook.lock_sheet": true,
+                "stage-rpt_generate_workbook.additional_columns": "decipher",
                 "stage-rpt_athena.name": "INPUT-sample_name",
                 "stage-rpt_athena.indication": "INPUT-clinical_indications",
                 "stage-rpt_athena.exons_file": "INPUT-exons_with_symbols",
@@ -245,7 +246,7 @@
                     }
                 },
                 "build": 38,
-                "select_tracks": "mane transcripts,refseq all"
+                "select_tracks": "MANE Transcripts,Refseq All"
             }
         }
     }


### PR DESCRIPTION
This pull request introduces updates to the `README.md` file and adds a new configuration file, `dias_CEN_config_GRCh38_v4.0.0.json`. The changes create allow for compatibility with Dias batch v3.3.0 for GRCh38.

* Updated the `README.md` with new GRCh38 file mappings. This ensures clear documentation of resources for both GRCh37 and GRCh38 builds.

* Introduced a new configuration file, `dias_CEN_config_GRCh38_v4.0.0.json`, which includes detailed settings for workflows, reference files, configs and input parameters.
  - Update all inputs to GRCh38 equivalents
  - Update to latest version of artemis and add new inputs
  - Update VEP folder input to eggd_additional_regions_calling
  - Change workbooks excluded/reorder for gnomAD v4.1 and Medicover
  - Updated filter strings to use CEN AFs.
  - Turned on decipher links in workbooks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/95)
<!-- Reviewable:end -->
