### PR TITLE
GRCh38: Update CEN VEP to v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following table lists the versions of apps, files, and docker images used in
 | file | exons | **GCF_000001405.39_GRCh38.p13_genomic_20211119.exon_5bp.tsv** | `file-GyFfgpQ4fJPv132574bFQfV5` | **GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gk7gZ47gypK7ZZ` |
 | file | genes2transcripts | **g2t_grch38_v2.0.0.tsv** | `file-J0v6GyQ4zqZJV047q56PqFx5` | **240402_g2t.tsv** | `file-Gj770X8433Gb506pjq1PxXG9` |
 | file | exons_with_symbols for eggd_athena | **GCF_000001405.39_GRCh38.p13_genomic_20211119.symbols.exon_5bp.tsv** | `file-Gyb29P84fJPqZJ37pfjz1vZB` | **GCF_000001405.25_GRCh37.p13_genomic.symbols.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gf99pBPbJkV7bq` |
-| config | cen_vep_config for SNV/mosaic reports | **cen_vep_config_GRCh38_v1.1.1.json** | `file-J0fx2Jj4z6j28KQjbzKgqgV2` | **cen_vep_config_v1.2.1.json** | `file-J04Kfv04z6j02Jz1Zj9VvK7k` |
+| config | cen_vep_config for SNV/mosaic reports | **cen_vep_config_GRCh38_v1.1.2.json** | `file-J18j1Zj4z6jGq1xvG8jFq6q6` | **cen_vep_config_v1.2.1.json** | `file-J04Kfv04z6j02Jz1Zj9VvK7k` |
 | config | cen_vep_config for CNV reports | **cen-cnv_config_GRCh38_v1.0.0.json** | `file-GyXyyp04Q8Xpj5fJ8v45by9k` | **cen-cnv_config_v1.1.0.json** | `file-GQGJ3Z84xyx0jp1q65K1Q1jY` |
 | file | panel_dump for eggd_optimised_filtering | **250530_panelapp_dump.json** | `file-J0yk3V04VVYxJ9bz3QPPzxPg` | **241030_panelapp_dump.json** | `file-GvVg3qj4Y54jBF8bgX62gkfQ` |
 | file | additional_regions for CNVs | **CEN_CNV_additional_regions_b38_v1.0.0.tsv** | `file-GfKb08j4679f4jbfxf8XP7JZ` | **CEN_CNV_additional_regions_b37_v1.0.1.tsv** | `file-GJZQvg0433GkyFZg13K6VV6p` |
@@ -46,7 +46,7 @@ The following table lists the versions of apps, files, and docker images used in
 
 ## Cmd to check the config file ids (not comprehensive)
 ```bash
-config_file="dias_CEN_config_GRCh38_v4.1.0.json"
+config_file="dias_CEN_config_GRCh38_v4.1.1.json"
 jq -r '.. | objects | .id? // empty' "${config_file}" | while read -r file_id; do
    dx describe "$file_id" --json | jq -r '"\(.id) \(.name)"';
 done

--- a/dias_CEN_config_GRCh38_v4.1.1.json
+++ b/dias_CEN_config_GRCh38_v4.1.1.json
@@ -1,6 +1,6 @@
 {
     "assay": "CEN",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "cnv_call_app_id": "app-GvZB5p846Vg69fBg0Fq10938",
     "artemis_app_id": "app-J13z26Q49bJkQvG7VB572x0b",
     "snv_report_workflow_id": "workflow-GkbJY284FpfgqF8ggz57fVY2",
@@ -129,7 +129,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-J0fx2Jj4z6j28KQjbzKgqgV2"
+                        "id": "file-J18j1Zj4z6jGq1xvG8jFq6q6"
                     }
                 },
                 "stage-rpt_vep.vcf": {
@@ -190,7 +190,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-J0fx2Jj4z6j28KQjbzKgqgV2"
+                        "id": "file-J18j1Zj4z6jGq1xvG8jFq6q6"
                     }
                 },
                 "stage-rpt_vep.vcf": {


### PR DESCRIPTION
Changes:

- update readme
- update config version
- update GRCh38 VEP config file to v1.1.2