### PR TITLE
Updated snv reports VEP config reference

### DIFF
--- a/dias_CEN_config_GRCh38_v4.8.2.json
+++ b/dias_CEN_config_GRCh38_v4.8.2.json
@@ -129,7 +129,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-J758VP84z6jGzGp10gYV946x"
+                        "id": "file-J7ZF9GQ4z6jGgj25KJQGB1y2"
                     }
                 },
                 "stage-rpt_vep.vcf": {


### PR DESCRIPTION
Updated SNV reports VEP config reference to point to `cen_vep_config_GRCh38_v1.2.2.json (file-J7ZF9GQ4z6jGgj25KJQGB1y2)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg5_dias_CEN_config/116)
<!-- Reviewable:end -->
